### PR TITLE
Fixed issue where command keyword is not always stripped, depending o…

### DIFF
--- a/webex_bot/webex_bot.py
+++ b/webex_bot/webex_bot.py
@@ -264,6 +264,6 @@ class WebexBot(WebexWebsocketClient):
         :return: message without command prefix
         """
 
-        if message.startswith(command):
+        if message.lower().startswith(command.lower()):
             return message[len(command):]
         return message


### PR DESCRIPTION
The `get_message_passed_to_command` function strips the command keyword from the message sent by the user, however this only happens if the capitalization matches. In testing, if the command sent by the user has different capitalization ("Command" vs "command"), then the command keyword is not stripped. 

I added a quick change to the `get_message_passed_to_command` function to fix this. 

For example, using a sample bot command that will echo the received message:

```
class TestCommand(Command):
    def __init__(self):
        super().__init__(
            command_keyword="test",
            help_message="test command.",
            card=None,
        )

    def execute(self, message, attachment_actions, activity):
        return ("Received message: " + message)
```

Then we see the following responses from the bot: 
![bot issue](https://user-images.githubusercontent.com/29705314/155414667-79ed58c8-e4c5-414d-9729-10732561f7f8.png)


Test reports: 
<img width="952" alt="webex_bot commit" src="https://user-images.githubusercontent.com/29705314/155413790-b9f12974-b906-482d-ab04-34aec6436fb7.png">
