### PR TITLE
add stop() call to gracefully exit the bot

### DIFF
--- a/webex_bot/websockets/webex_websocket_client.py
+++ b/webex_bot/websockets/webex_websocket_client.py
@@ -134,6 +134,14 @@ class WebexWebsocketClient(object):
         logger.debug(f"self.device_info: {self.device_info}")
         return resp
 
+
+    def stop(self):
+      def terminate():
+          raise SystemExit()
+
+      asyncio.get_event_loop().create_task(terminate())
+
+
     def run(self):
         if self.device_info is None:
             if self._get_device_info() is None:


### PR DESCRIPTION
when using the bot framework in a service, I needed a way to gracefully stop the process loop from an external trigger.

```python
bot = WebexBot(...)

def graceful_exit()
    cysystemd.daemon.notify(cysystemd.daemon.Notification.STOPPING)
    bot.stop()

signal.signal(signal.SIGTERM, graceful_exit)
bot.run()
```