### PR TITLE
Fix the bug that wrong cmd hit when the cmd text is duplicated in the…

### DIFF
--- a/webex_bot/webex_bot.py
+++ b/webex_bot/webex_bot.py
@@ -222,7 +222,7 @@ class WebexBot(WebexWebsocketClient):
 
             if not is_card_callback_command and c.command_keyword:
                 log.debug(f"c.command_keyword: {c.command_keyword}")
-                if user_command.find(c.command_keyword) != -1:
+                if user_command.strip().split()[0].lower() == c.command_keyword.lower():
                     command = c
                     # If a command was found, stop looking for others
                     break


### PR DESCRIPTION
Bug Description:
I added 2 commands, command_keyword='build' and command_keyword='signature'.
Both have is_card_callback_command = False.
As a user typed in such command string: "build start name=release_1.2.0_qa_build_no_signature_check", within which "signature" is just dup to that "signature" command.
"signature" rather than "build" was hit.