### PR TITLE
Add support for proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ You can find a sample project, using OpenAI/ChatGPT with this library here: http
 
 `pip install webex_bot`
 
+If you need optional proxy support, use this command instead:
+
+`pip install webex_bot[proxy]`
+
 2. On the Webex Developer portal, create a new [bot token][3] and expose it as an environment variable.
 
 ```sh

--- a/example.py
+++ b/example.py
@@ -3,11 +3,18 @@ import os
 from webex_bot.commands.echo import EchoCommand
 from webex_bot.webex_bot import WebexBot
 
+# (Optional) Proxy configuration
+proxies = {
+    'https': 'http://proxy.esl.example.com:80',
+    'wss': 'socks5://proxy.esl.example.com:1080'
+}
+
 # Create a Bot Object
 bot = WebexBot(teams_bot_token=os.getenv("WEBEX_TEAMS_ACCESS_TOKEN"),
                approved_rooms=['06586d8d-6aad-4201-9a69-0bf9eeb5766e'],
                bot_name="My Teams Ops Bot",
-               include_demo_commands=True)
+               include_demo_commands=True,
+               proxies=proxies)
 
 # Add new commands for the bot to listen out for.
 bot.add_command(EchoCommand())

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,10 @@ setup_requirements = ["pytest-runner"]
 
 test_requirements = ["pytest>=3"]
 
+extras_requirements = {
+    "proxy": ["websockets_proxy>=0.1.1"]
+}
+
 setup(
     author="Finbarr Brady",
     author_email="finbarr.brady@gmail.com",
@@ -26,6 +30,7 @@ setup(
         "Programming Language :: Python :: 3.9",
     ],
     description="Python package for a Webex Bot based on websockets.",
+    extras_require=extras_requirements,
     install_requires=requirements,
     license="MIT license",
     long_description=readme,

--- a/webex_bot/webex_bot.py
+++ b/webex_bot/webex_bot.py
@@ -32,7 +32,8 @@ class WebexBot(WebexWebsocketClient):
                  device_url=DEFAULT_DEVICE_URL,
                  include_demo_commands=False,
                  bot_name="Webex Bot",
-                 bot_help_subtitle="Here are my available commands. Click one to begin."):
+                 bot_help_subtitle="Here are my available commands. Click one to begin.",
+                 proxies=None):
         """
         Initialise WebexBot.
 
@@ -44,6 +45,7 @@ class WebexBot(WebexWebsocketClient):
         @param include_demo_commands: If True, any demo commands will be included.
         @param bot_name: Your custom name for the bot.
         @param bot_help_subtitle: Text to show in the help card.
+        @param proxies: Dictionary of proxies for connections.
         """
 
         log.info("Registering bot with Webex cloud")
@@ -51,7 +53,8 @@ class WebexBot(WebexWebsocketClient):
                                       teams_bot_token,
                                       on_message=self.process_incoming_message,
                                       on_card_action=self.process_incoming_card_action,
-                                      device_url=device_url)
+                                      device_url=device_url,
+                                      proxies=proxies)
 
         # A dictionary of commands this bot listens to
         # Each key in the dictionary is a command, with associated help

--- a/webex_bot/websockets/webex_websocket_client.py
+++ b/webex_bot/websockets/webex_websocket_client.py
@@ -11,6 +11,12 @@ import requests
 import websockets
 from webexteamssdk import WebexTeamsAPI
 
+try:
+    from websockets_proxy import Proxy, proxy_connect
+except ImportError:
+    Proxy = None
+    proxy_connect = None
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_DEVICE_URL = "https://wdm-a.wbx2.com/wdm/api/v1"
@@ -34,14 +40,21 @@ class WebexWebsocketClient(object):
                  access_token,
                  device_url=DEFAULT_DEVICE_URL,
                  on_message=None,
-                 on_card_action=None):
+                 on_card_action=None,
+                 proxies=None):
         self.access_token = access_token
-        self.teams = WebexTeamsAPI(access_token=access_token)
+        self.teams = WebexTeamsAPI(access_token=access_token, proxies=proxies)
         self.device_url = device_url
         self.device_info = None
         self.on_message = on_message
         self.on_card_action = on_card_action
+        self.proxies = proxies
         self.websocket = None
+
+        if self.proxies and "wss" in self.proxies:
+            # Connecting wss:// through a proxy
+            if proxy_connect is None:
+                raise ImportError("Failed to load libraries for proxy, maybe forgot [proxy] option during installation.")
 
     def _process_incoming_websocket_message(self, msg):
         """
@@ -91,7 +104,8 @@ class WebexWebsocketClient(object):
                                                             f"{verb}/{activity_id}")
         headers = {"Authorization": f"Bearer {self.access_token}"}
         conversation_message = requests.get(conversation_message_url,
-                                            headers=headers).json()
+                                            headers=headers,
+                                            proxies=self.proxies).json()
         logger.debug(f"conversation_message={conversation_message}")
         return conversation_message['id']
 
@@ -158,7 +172,16 @@ class WebexWebsocketClient(object):
         async def _connect_and_listen():
             ws_url = self.device_info['webSocketUrl']
             logger.info(f"Opening websocket connection to {ws_url}")
-            async with websockets.connect(ws_url, ssl=ssl_context) as _websocket:
+
+            if self.proxies and "wss" in self.proxies:
+                logger.info(f"Using proxy for websocket connection: {self.proxies['wss']}")
+                proxy = Proxy.from_url(self.proxies["wss"])
+                connect = proxy_connect(ws_url, ssl=ssl_context, proxy=proxy)
+            else:
+                logger.debug(f"Not using proxy for websocket connection.")
+                connect = websockets.connect(ws_url, ssl=ssl_context)
+
+            async with connect as _websocket:
                 self.websocket = _websocket
                 logger.info("WebSocket Opened.")
                 msg = {'id': str(uuid.uuid4()),


### PR DESCRIPTION
This pull request makes it possible to use the `webex_bot` in a proxy environment. As support for proxies in `websockets` has been stucked for over five years (ref. https://github.com/python-websockets/websockets/issues/364), I've decided to introduce [the `websockets_proxy` library](https://pypi.org/project/websockets-proxy/) as a drop-in replacement.

The additional library is not necessary for those who do not require a proxy, so it might be better to offer this feature as an optional. To support proxies, you will need to explicitly include the `[proxy]` option when installing.

fixes #35 #39