### PR TITLE
Initial Support for messages with file attachments

### DIFF
--- a/webex_bot/webex_bot.py
+++ b/webex_bot/webex_bot.py
@@ -187,7 +187,7 @@ class WebexBot(WebexWebsocketClient):
         :return:
         """
         user_email = teams_message.personEmail
-        raw_message = teams_message.text
+        raw_message = teams_message.text or ""
         is_one_on_one_space = 'ONE_ON_ONE' in activity['target']['tags']
 
         if activity['actor']['type'] != 'PERSON':

--- a/webex_bot/websockets/webex_websocket_client.py
+++ b/webex_bot/websockets/webex_websocket_client.py
@@ -50,7 +50,7 @@ class WebexWebsocketClient(object):
         """
         if msg['data']['eventType'] == 'conversation.activity':
             activity = msg['data']['activity']
-            if activity['verb'] == 'post':
+            if activity['verb'] in ["post", "share"]:
                 logger.debug(f"activity={activity}")
 
                 message_base_64_id = self._get_base64_message_id(activity)
@@ -83,10 +83,10 @@ class WebexWebsocketClient(object):
         @return: base 64 message id
         """
         activity_id = activity['id']
-        logger.debug(f"activity verb=post. message id={activity_id}")
+        logger.debug(f"activity verb={activity['verb']}. message id={activity_id}")
         conversation_url = activity['target']['url']
         conv_target_id = activity['target']['id']
-        verb = "messages" if activity['verb'] == "post" else "attachment/actions"
+        verb = "messages" if activity['verb'] in ["post", "share"] else "attachment/actions"
         conversation_message_url = conversation_url.replace(f"conversations/{conv_target_id}",
                                                             f"{verb}/{activity_id}")
         headers = {"Authorization": f"Bearer {self.access_token}"}


### PR DESCRIPTION
This Pull Request introduces basic support for the 'share' verb, enabling the handling of messages with file attachments.

A key point to note is that there are two patterns of messages with files: those that come with text and those that are sent without any text, containing only the file(s).

For messages without text, the message object retrieved by `self.teams.messages.get(message_base_64_id)` does not contain a `text`. An example of such a message object is as follows:

```json
{
  "id": "<snip>",
  "roomId": "<snip>",
  "roomType": "direct",
  "files": [
    "https://webexapis.com/v1/contents/<snip>"
  ],
  "personId": "<snip>",
  "personEmail": "<snip>",
  "created": "2024-03-05T03:46:01.711Z",
  "isVoiceClip": false
}
```

When a command is not understood or is absent, the help_command is invoked. So it's important to remember that the help_command will be always executed when a message contains only a file, with no accompanying text.

While I believe there may be a better approach, this PR serves to implement the necessary minimum support. Further improvements can be built upon this foundation.

Please review the changes, and if there are any additional considerations or modifications needed, please let me know. Thank you!

potentially fixes #38