### PR TITLE
Add hidden commands for admin purposes

### DIFF
--- a/webex_bot/commands/help.py
+++ b/webex_bot/commands/help.py
@@ -76,17 +76,19 @@ class HelpCommand(Command):
             # Sort list by keyword
             sorted_commands_list = sorted(self.commands, key=lambda command: (
                 command.command_keyword is not None, command.command_keyword))
+
             for command in sorted_commands_list:
-                if command.help_message and command.command_keyword != HELP_COMMAND_KEYWORD:
-                    action = Submit(
-                        title=f"{command.help_message}",
-                        data={COMMAND_KEYWORD_KEY: command.command_keyword,
-                              'thread_parent_id': thread_parent_id},
-                    )
-                    help_actions.append(action)
+                if not command.admin_command:
+                    if command.help_message and command.command_keyword != HELP_COMMAND_KEYWORD:
+                        action = Submit(
+                            title=f"{command.help_message}",
+                            data={COMMAND_KEYWORD_KEY: command.command_keyword,
+                                  'thread_parent_id': thread_parent_id},
+                        )
+                        help_actions.append(action)
 
-                    hint = Fact(title=command.command_keyword,
-                                value=command.help_message)
+                        hint = Fact(title=command.command_keyword,
+                                    value=command.help_message)
 
-                    hint_texts.append(hint)
+                        hint_texts.append(hint)
         return help_actions, hint_texts

--- a/webex_bot/models/command.py
+++ b/webex_bot/models/command.py
@@ -11,7 +11,7 @@ class Command(ABC):
 
     def __init__(self, command_keyword=None, chained_commands=[], card=None, help_message=None,
                  delete_previous_message=False,
-                 card_callback_keyword=None, approved_rooms=None):
+                 card_callback_keyword=None, approved_rooms=None, admin_command=None):
         """
         Create a new bot command.
 
@@ -45,6 +45,7 @@ class Command(ABC):
         self.delete_previous_message = delete_previous_message
         self.approved_rooms = approved_rooms
         self.chained_commands = chained_commands
+        self.admin_command = admin_command
 
         # Now, if this card has a Action.Submit action, let's read the callback keyword,
         # or if it doesnt exist, add it.

--- a/webex_bot/webex_bot.py
+++ b/webex_bot/webex_bot.py
@@ -29,6 +29,7 @@ class WebexBot(WebexWebsocketClient):
                  approved_users=[],
                  approved_domains=[],
                  approved_rooms=[],
+                 approved_admins=[],
                  device_url=DEFAULT_DEVICE_URL,
                  include_demo_commands=False,
                  bot_name="Webex Bot",
@@ -74,6 +75,7 @@ class WebexBot(WebexWebsocketClient):
         self.approved_users = approved_users
         self.approved_domains = approved_domains
         self.approved_rooms = approved_rooms
+        self.approved_admins = approved_admins
         # Set default help message
         self.help_message = "Hello!  I understand the following commands:  \n"
         self.approval_parameters_check()
@@ -146,6 +148,16 @@ class WebexBot(WebexWebsocketClient):
         if not user_approved:
             log.warning(f"{user_email} is not approved to interact at this time. Ignoring.")
         return user_approved
+
+    def check_user_admin(self, user_email, approved_admins):
+        is_an_admin = False
+
+        if approved_admins is None:
+            is_an_admin = False
+        elif user_email in approved_admins:
+            is_an_admin = True
+
+        return is_an_admin
 
     def is_user_member_of_room(self, user_email, approved_rooms):
         is_user_member = False
@@ -242,6 +254,10 @@ class WebexBot(WebexWebsocketClient):
                 if not self.check_user_approved(user_email=user_email, approved_rooms=command.approved_rooms):
                     log.info(f"{user_email} is not allowed to run command: '{command.command_keyword}'")
                     return
+
+            if command.admin_command and not self.check_user_admin(user_email=user_email,approved_admins=command.approved_admins):
+                log.info(f"{user_email} is not allowed to run command: '{command.command_keyword}' as it is an admin command")
+                return
 
         # Build the reply to the user
         reply = ""


### PR DESCRIPTION
This pull request will allow users to have administrative/hidden commands.  These commands will not show up in the help card and will only be allowable to a approved user list, much like the approved_rooms variable. Otherwise the bot will not respond to them.  

When creating a new command you can specify the following:

approved_admins=self.cfg['approved_admins']
admin_command=True,

For questions I can be reached directly here: jafilson@cisco.com.


