### PR TITLE
Add web socket Max backoff time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ from setuptools import setup, find_packages
 with open('README.md') as readme_file:
     readme = readme_file.read()
 
+# For latest unreleased version use
+# `webexteamssdk@ git+https://github.com/WebexCommunity/WebexPythonSDK.git`
 requirements = ['webexteamssdk==1.6.1', 'coloredlogs', 'websockets==10.2', 'backoff']
 
 setup_requirements = ['pytest-runner', ]

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ from setuptools import setup, find_packages
 with open("README.md") as readme_file:
     readme = readme_file.read()
 
+# For latest unreleased version use
+# `webexteamssdk@ git+https://github.com/WebexCommunity/WebexPythonSDK.git`
 requirements = ["webexteamssdk==1.6.1", "coloredlogs", "websockets==11.0.3", "backoff"]
 
 setup_requirements = ["pytest-runner"]

--- a/webex_bot/websockets/webex_websocket_client.py
+++ b/webex_bot/websockets/webex_websocket_client.py
@@ -28,6 +28,7 @@ DEVICE_DATA = {
 ssl_context = ssl.create_default_context()
 ssl_context.load_verify_locations(certifi.where())
 
+MAX_BACKOFF_TIME = 240
 
 class WebexWebsocketClient(object):
     def __init__(self,
@@ -151,10 +152,10 @@ class WebexWebsocketClient(object):
                 logger.warning(
                     f"An exception occurred while processing message. Ignoring. {messageProcessingException}")
 
-        @backoff.on_exception(backoff.expo, websockets.ConnectionClosedError)
-        @backoff.on_exception(backoff.expo, websockets.ConnectionClosedOK)
-        @backoff.on_exception(backoff.expo, websockets.ConnectionClosed)
-        @backoff.on_exception(backoff.expo, socket.gaierror)
+        @backoff.on_exception(backoff.expo, websockets.ConnectionClosedError, max_time=MAX_BACKOFF_TIME)
+        @backoff.on_exception(backoff.expo, websockets.ConnectionClosedOK, max_time=MAX_BACKOFF_TIME)
+        @backoff.on_exception(backoff.expo, websockets.ConnectionClosed, max_time=MAX_BACKOFF_TIME)
+        @backoff.on_exception(backoff.expo, socket.gaierror, max_time=MAX_BACKOFF_TIME)
         async def _connect_and_listen():
             ws_url = self.device_info['webSocketUrl']
             logger.info(f"Opening websocket connection to {ws_url}")


### PR DESCRIPTION
The `backoff.expo` decorator provides "exponential backoff". This design pattern is common in connection recovery scenarios where multiple or continuous connection attempts might be penalized with temporary or permanent bans, or it might simply be a waste of resources when connection is not possible due to network conditions. By using an exponential backoff algorithm, each subsequent attempt waits for a longer delay between retries, thus reducing load and respecting policies.

However,  we didnt have a maximum backoff time is specified. The calculation for the backoff time is (factor * (2 ** (num_retries - 1))) (num_retries gets incremented after each fail), where "factor" takes default value 1 second. After a number of failures, the delay between retries can become very long.
