### PR TITLE
Introduce exact_command_keyword_match feature

### DIFF
--- a/webex_bot/models/command.py
+++ b/webex_bot/models/command.py
@@ -9,8 +9,9 @@ COMMAND_KEYWORD_KEY = "command_keyword"
 
 class Command(ABC):
 
-    def __init__(self, command_keyword=None, chained_commands=[], card=None, help_message=None,
-                 delete_previous_message=False,
+    def __init__(self, command_keyword=None, exact_command_keyword_match=False,
+                 chained_commands=[], card=None,
+                 help_message=None, delete_previous_message=False,
                  card_callback_keyword=None, approved_rooms=None):
         """
         Create a new bot command.
@@ -25,6 +26,7 @@ class Command(ABC):
                     )
 
         @param command_keyword: (optional) Text indicating a phrase to invoke this card.
+        @param exact_command_keyword_match: If True, there will be an exact command_keyword match performed. If False, then a sub-string match will be performed. Default: False. 
         @param chained_commands: (optional) List of other commands related
         to this command. This allows multiple related cards to be added at once.
         @param card: (deprecated) A dict representation of the JSON card.
@@ -37,6 +39,7 @@ class Command(ABC):
         @param approved_rooms: If defined, only members of these spaces will be allowed to run this command. Default: None (everyone)
         """
         self.command_keyword = command_keyword
+        self.exact_command_keyword_match = exact_command_keyword_match
         self.help_message = help_message
         self.card = card
         self.pre_card_callback = self.execute

--- a/webex_bot/webex_bot.py
+++ b/webex_bot/webex_bot.py
@@ -234,10 +234,21 @@ class WebexBot(WebexWebsocketClient):
 
             if not is_card_callback_command and c.command_keyword:
                 log.debug(f"c.command_keyword: {c.command_keyword}")
-                if user_command.find(c.command_keyword) != -1:
-                    command = c
-                    # If a command was found, stop looking for others
-                    break
+                log.info(f"exact_command_keyword_match: {c.exact_command_keyword_match}")
+                log.info(f"user_command: {user_command}")
+                log.info(f"command_keyword: {c.command_keyword}")
+                if c.exact_command_keyword_match: # Check if the "exact_command_keyword_match" flag is set to True
+                    if user_command == c.command_keyword:
+                        log.info("Exact match found!")
+                        command=c
+                        # If a command was found, stop looking for others
+                        break
+                else: # Enter here if the "exact_command_keyword_match" flag is set to False
+                    if user_command.find(c.command_keyword) != -1:
+                        log.info("Sub-string match found!")
+                        command = c
+                        # If a command was found, stop looking for others
+                        break
             else:
                 log.debug(f"card_callback_keyword: {c.card_callback_keyword}")
                 if user_command == c.command_keyword or user_command == c.card_callback_keyword:


### PR DESCRIPTION
If the command_keyword is set to "hi", and if the user issues "delhi" to the bot, then webex_bot.py allows it as it performs a sub-string match with "if user_command.find(c.command_keyword) != -1:" in process_raw_command().

With these changes, we can set webex_bot.py to perform an exact command_keyword match with a new flag "exact_command_keyword_match" from the Command class. Also, for backward compatibility, the default behaviour of the flag is set to False if undefined. So, we can have the benefits of both the worlds at each command level.