### PR TITLE
Migrate from "webexteamssdk" library to "webexpythonsdk" library

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ and off you go!
 
 [1]: https://github.com/aaugustin/websockets
 
-[2]: https://github.com/CiscoDevNet/webexpythonsdk
+[2]: https://github.com/WebexCommunity/WebexPythonSDK
 
 [3]: https://developer.webex.com/docs/bots
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ inside a LAN. This package instead uses a websocket to receive messages from the
 * Allows for single or multi-post responses. This is useful if you want to reply with a lot of data, but it won't all
   fit in a single response.
 * Restrict bot to certain users or domains.
-* Uses the [webexteamssdk][2] package to send back replies from the bot.
+* Uses the [webexpythonsdk][2] package to send back replies from the bot.
 
 ## 🚀 Getting started
 
@@ -48,7 +48,7 @@ If you need optional proxy support, use this command instead:
 2. On the Webex Developer portal, create a new [bot token][3] and expose it as an environment variable.
 
 ```sh
-export WEBEX_TEAMS_ACCESS_TOKEN=<your bots token>
+export WEBEX_ACCESS_TOKEN=<your bots token>
 ```
 
 3. Run your script:
@@ -71,7 +71,7 @@ proxies = {
 }
 
 # Create a Bot Object
-bot = WebexBot(teams_bot_token=os.getenv("WEBEX_TEAMS_ACCESS_TOKEN"),
+bot = WebexBot(teams_bot_token=os.getenv("WEBEX_ACCESS_TOKEN"),
                approved_rooms=['06586d8d-6aad-4201-9a69-0bf9eeb5766e'],
                bot_name="My Teams Ops Bot",
                include_demo_commands=True,
@@ -89,9 +89,9 @@ where EchoCommand is defined as:
 ```python
 import logging
 
-from webexteamssdk.models.cards import Colors, TextBlock, FontWeight, FontSize, Column, AdaptiveCard, ColumnSet, \
+from webexpythonsdk.models.cards import Colors, TextBlock, FontWeight, FontSize, Column, AdaptiveCard, ColumnSet, \
     Text, Image, HorizontalAlignment
-from webexteamssdk.models.cards.actions import Submit
+from webexpythonsdk.models.cards.actions import Submit
 
 from webex_bot.formatting import quote_info
 from webex_bot.models.command import Command
@@ -370,7 +370,7 @@ and off you go!
 
 [1]: https://github.com/aaugustin/websockets
 
-[2]: https://github.com/CiscoDevNet/webexteamssdk
+[2]: https://github.com/CiscoDevNet/webexpythonsdk
 
 [3]: https://developer.webex.com/docs/bots
 

--- a/example.py
+++ b/example.py
@@ -11,7 +11,7 @@ proxies = {
 }
 
 # Create a Bot Object
-bot = WebexBot(teams_bot_token=os.getenv("WEBEX_TEAMS_ACCESS_TOKEN"),
+bot = WebexBot(teams_bot_token=os.getenv("WEBEX_ACCESS_TOKEN"),
                approved_rooms=['06586d8d-6aad-4201-9a69-0bf9eeb5766e'],
                bot_name="My Teams Ops Bot",
                include_demo_commands=True,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,6 +7,6 @@ tox==3.14.0
 coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0
-webexteamssdk==1.6.1
+webexpythonsdk
 pytest==4.6.5
 pytest-runner==5.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,6 +7,6 @@ tox==3.14.0
 coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0
-webexpythonsdk
+webexpythonsdk==2.0.1
 pytest==4.6.5
 pytest-runner==5.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,6 +7,6 @@ tox==3.14.0
 coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0
-webexpythonsdk==2.0.1
+webexpythonsdk
 pytest==4.6.5
 pytest-runner==5.1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 with open('README.md') as readme_file:
     readme = readme_file.read()
 
-requirements = ['webexpythonsdk', 'coloredlogs', 'websockets==11.0.3', 'backoff']
+requirements = ['webexpythonsdk==2.0.1', 'coloredlogs', 'websockets==11.0.3', 'backoff']
 
 setup_requirements = ['pytest-runner', ]
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 with open('README.md') as readme_file:
     readme = readme_file.read()
 
-requirements = ['webexpythonsdk==2.0.1', 'coloredlogs', 'websockets==11.0.3', 'backoff']
+requirements = ['webexpythonsdk', 'coloredlogs', 'websockets==11.0.3', 'backoff']
 
 setup_requirements = ['pytest-runner', ]
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 with open('README.md') as readme_file:
     readme = readme_file.read()
 
-requirements = ['webexteamssdk==1.6.1', 'coloredlogs', 'websockets==11.0.3', 'backoff']
+requirements = ['webexpythonsdk', 'coloredlogs', 'websockets==11.0.3', 'backoff']
 
 setup_requirements = ['pytest-runner', ]
 

--- a/webex_bot/commands/echo.py
+++ b/webex_bot/commands/echo.py
@@ -1,8 +1,8 @@
 import logging
 
-from webexteamssdk.models.cards import Colors, TextBlock, FontWeight, FontSize, Column, AdaptiveCard, ColumnSet, \
+from webexpythonsdk.models.cards import Colors, TextBlock, FontWeight, FontSize, Column, AdaptiveCard, ColumnSet, \
     Text, Image, HorizontalAlignment
-from webexteamssdk.models.cards.actions import Submit
+from webexpythonsdk.models.cards.actions import Submit
 
 from webex_bot.formatting import quote_info
 from webex_bot.models.command import Command

--- a/webex_bot/commands/help.py
+++ b/webex_bot/commands/help.py
@@ -1,8 +1,8 @@
 import logging
 
-from webexteamssdk.models.cards import Colors, TextBlock, FontWeight, FontSize, Column, AdaptiveCard, ColumnSet, \
+from webexpythonsdk.models.cards import Colors, TextBlock, FontWeight, FontSize, Column, AdaptiveCard, ColumnSet, \
     ImageSize, Image, Fact
-from webexteamssdk.models.cards.actions import Submit
+from webexpythonsdk.models.cards.actions import Submit
 
 from webex_bot.models.command import Command, COMMAND_KEYWORD_KEY
 from webex_bot.models.response import response_from_adaptive_card

--- a/webex_bot/models/command.py
+++ b/webex_bot/models/command.py
@@ -30,7 +30,7 @@ class Command(ABC):
         @param chained_commands: (optional) List of other commands related
         to this command. This allows multiple related cards to be added at once.
         @param card: (deprecated) A dict representation of the JSON card.
-        Prefer to use cards built in code using the webexteamssdk.models.cards classes
+        Prefer to use cards built in code using the webexpythonsdk.models.cards classes
         (see https://github.com/fbradyirl/webex_bot/blob/main/webex_bot/commands/echo.py for example)
         @param help_message: Short description of this command.
         @param delete_previous_message: If True, the card which invoked this command will be deleted. (default False)
@@ -55,7 +55,7 @@ class Command(ABC):
         if card is not None:
             log.warning(f"[{command_keyword}]. Using a card dict is now deprecated. "
                         f"Switch to use adaptive cards built in code "
-                        "using the webexteamssdk.models.cards classes (see "
+                        "using the webexpythonsdk.models.cards classes (see "
                         "https://github.com/fbradyirl/webex_bot/blob/main/webex_bot/commands/echo.py for example)")
             if 'actions' in card:
                 if len(card['actions']) > 0:

--- a/webex_bot/models/command.py
+++ b/webex_bot/models/command.py
@@ -9,8 +9,9 @@ COMMAND_KEYWORD_KEY = "command_keyword"
 
 class Command(ABC):
 
-    def __init__(self, command_keyword=None, chained_commands=[], card=None, help_message=None,
-                 delete_previous_message=False,
+    def __init__(self, command_keyword=None, exact_command_keyword_match=False,
+                 chained_commands=[], card=None,
+                 help_message=None, delete_previous_message=False,
                  card_callback_keyword=None, approved_rooms=None):
         """
         Create a new bot command.
@@ -25,6 +26,7 @@ class Command(ABC):
                     )
 
         @param command_keyword: (optional) Text indicating a phrase to invoke this card.
+        @param exact_command_keyword_match: If True, there will be an exact command_keyword match performed. If False, then a sub-string match will be performed. Default: False. 
         @param chained_commands: (optional) List of other commands related
         to this command. This allows multiple related cards to be added at once.
         @param card: (deprecated) A dict representation of the JSON card.
@@ -37,6 +39,7 @@ class Command(ABC):
         @param approved_rooms: If defined, only members of these spaces will be allowed to run this command. Default: None (everyone)
         """
         self.command_keyword = command_keyword
+        self.exact_command_keyword_match = exact_command_keyword_match
         self.help_message = help_message
         self.card = card
         self.pre_card_callback = self.execute

--- a/webex_bot/models/response.py
+++ b/webex_bot/models/response.py
@@ -1,6 +1,6 @@
 import json
 
-from webexteamssdk.models.cards import AdaptiveCard
+from webexpythonsdk.models.cards import AdaptiveCard
 
 
 def response_from_adaptive_card(adaptive_card: AdaptiveCard):

--- a/webex_bot/webex_bot.py
+++ b/webex_bot/webex_bot.py
@@ -5,7 +5,7 @@ import os
 import backoff
 import coloredlogs
 import requests
-import webexteamssdk
+import webexpythonsdk
 
 from webex_bot.commands.echo import EchoCommand
 from webex_bot.commands.help import HelpCommand
@@ -95,7 +95,7 @@ class WebexBot(WebexWebsocketClient):
     @backoff.on_exception(backoff.expo, requests.exceptions.ConnectionError)
     def get_me_info(self):
         """
-        Fetch me info from webexteamssdk
+        Fetch me info from webexpythonsdk
         """
         me = self.teams.people.me()
         self.bot_display_name = me.displayName
@@ -168,7 +168,7 @@ class WebexBot(WebexWebsocketClient):
                 for member in room_members:
                     if member.personEmail == user_email:
                         is_user_member = True
-            except webexteamssdk.exceptions.ApiError as apie:
+            except webexpythonsdk.exceptions.ApiError as apie:
                 log.warn(f"API error: {apie}")
         return is_user_member
 

--- a/webex_bot/webex_bot.py
+++ b/webex_bot/webex_bot.py
@@ -234,10 +234,21 @@ class WebexBot(WebexWebsocketClient):
 
             if not is_card_callback_command and c.command_keyword:
                 log.debug(f"c.command_keyword: {c.command_keyword}")
-                if user_command.find(c.command_keyword) != -1:
-                    command = c
-                    # If a command was found, stop looking for others
-                    break
+                log.info(f"exact_command_keyword_match: {c.exact_command_keyword_match}")
+                log.info(f"user_command: {user_command}")
+                log.info(f"command_keyword: {c.command_keyword}")
+                if c.exact_command_keyword_match: # Check if the "exact_command_keyword_match" flag is set to True
+                    if user_command == c.command_keyword:
+                        log.info("Exact match found!")
+                        command=c
+                        # If a command was found, stop looking for others
+                        break
+                else: # Enter here if the "exact_command_keyword_match" flag is set to False
+                    if user_command.find(c.command_keyword) != -1:
+                        log.info("Sub-string match found!")
+                        command = c
+                        # If a command was found, stop looking for others
+                        break
             else:
                 log.debug(f"card_callback_keyword: {c.card_callback_keyword}")
                 if user_command == c.command_keyword or user_command == c.card_callback_keyword:

--- a/webex_bot/websockets/webex_websocket_client.py
+++ b/webex_bot/websockets/webex_websocket_client.py
@@ -9,7 +9,7 @@ import backoff
 import certifi
 import requests
 import websockets
-from webexteamssdk import WebexTeamsAPI
+from webexpythonsdk import WebexAPI
 
 try:
     from websockets_proxy import Proxy, proxy_connect
@@ -45,7 +45,7 @@ class WebexWebsocketClient(object):
                  on_card_action=None,
                  proxies=None):
         self.access_token = access_token
-        self.teams = WebexTeamsAPI(access_token=access_token, proxies=proxies)
+        self.teams = WebexAPI(access_token=access_token, proxies=proxies)
         self.device_url = device_url
         self.device_info = None
         self.on_message = on_message


### PR DESCRIPTION
Migration from "webexteamssdk" library to "webexpythonsdk" library.

All instances of package name "webexteamssdk" is replaced with "webexpythonsdk".
All instances of primary API object "WebexTeamsAPI" is replaced with "WebexAPI".
All instances of access token environment variable "WEBEX_TEAMS_ACCESS_TOKEN" is replaced with "WEBEX_ACCESS_TOKEN".

Changes are inline with "https://webexcommunity.github.io/WebexPythonSDK/user/migrate.html" and tested with my local Webex bot (which resulted in no errors). Only thing is all instances of "webexteamssdk" references in local Webex bot had to be replaced with "webexpythonsdk".