### PR TITLE
[feature] Add support for generators returned by commands

### DIFF
--- a/webex_bot/webex_bot.py
+++ b/webex_bot/webex_bot.py
@@ -2,6 +2,7 @@
 import logging
 import os
 
+import types
 import backoff
 import coloredlogs
 import requests
@@ -336,7 +337,7 @@ class WebexBot(WebexWebsocketClient):
             self.teams.messages.create(**reply)
             reply = "ok"
         # Support returning a list of Responses
-        elif reply and isinstance(reply, list):
+        elif reply and (isinstance(reply, list) or isinstance(reply, types.GeneratorType)):
             for response in reply:
                 # Make sure is a Response
                 if isinstance(response, Response):


### PR DESCRIPTION
Simple change to allow commands to return generators instead of a list of responses allowing the bot to stream responses back as they arrive from a source.

Example of what a command might look llike:

```python
import logging
from webex_bot.models.response import Response

log = logging.getLogger(__name__)


class StreamCommand(Command):

    def __init__(self):
        super().__init__(
            command_keyword="stream",
            help_message="Stream Stuff Back to You!",
        )

    def execute(self, message, attachment_actions, activity):
        """
        If you want to respond to a submit operation on the card, you
        would write code here!

        You can return text string here or even another card (Response).

        This sample command function simply echos back the sent message.

        :param message: message with command already stripped
        :param attachment_actions: attachment_actions object
        :param activity: activity object

        :return: a string or Response object (a list or generator of either). Use Response if you want to return another card.
        """

        client = get_api_or_db_client()

        # a long running query that might stream messages back to the client
        for message in client.run_query():

            yield Response(attributes={"markdown": message, "roomId": None, "parentId": None})
```
