### PR TITLE
Add header for connection behind proxy

### DIFF
--- a/webex_bot/websockets/webex_websocket_client.py
+++ b/webex_bot/websockets/webex_websocket_client.py
@@ -87,12 +87,18 @@ class WebexWebsocketClient(object):
         self.device_url = self._get_device_url()
 
     def _get_headers(self):
-        return {
+
+        headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-type": "application/json;charset=utf-8",
             "User-Agent": f"webex_bot/{__version__}{self.add_to_ua}",
             "trackingid": self.tracking_id
         }
+
+        if self.proxies:
+            headers["Connection"] = f"close"
+
+        return headers
 
     def _get_websocket_connect_kwargs(self, connect_func):
         headers = self._get_headers()


### PR DESCRIPTION
The modification adds the header `"Connection" : "close"`. This forces the HTTP client, which is used to retrieve messages, not to keep TCP sessions open. The problem with proxies is that they normally close idle TCP sessions, so if the TCP sessions are opened and closed per transaction, then whatever the proxy does does not affect the HTTP client of the bot.