### PR TITLE
fix: support Python 3.14 event loops

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             max-parallel: 5
             matrix:
-                python-version: [ "3.10", "3.11", "3.12" ]
+                python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
 
         steps:
             -   uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can find a sample project, using OpenAI/ChatGPT with this library here: http
 
 ----
 
-**Python 3.10, 3.11, and 3.12 are tested at this time.**
+**Python 3.10 through 3.14 are tested.**
 
 1. Install this module from pypi:
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
     ],
     description="Python package for a Webex Bot based on websockets.",
     extras_require=extras_requirements,

--- a/tests/test_webex_websocket_client.py
+++ b/tests/test_webex_websocket_client.py
@@ -1,4 +1,7 @@
+import asyncio
 from unittest.mock import MagicMock
+
+import pytest
 
 from webex_bot.websockets.webex_websocket_client import (
     WebexWebsocketClient,
@@ -75,6 +78,29 @@ def test_invalid_status_not_in_backoff_exceptions():
         "InvalidStatus should not be in BACKOFF_EXCEPTIONS. "
         "404 errors need immediate device refresh, not backoff retries."
     )
+
+
+def test_run_creates_and_sets_an_event_loop(monkeypatch):
+    client = _make_client()
+    client.device_info = {"webSocketUrl": "wss://example.com"}
+    client.proxies = None
+
+    event_loop = MagicMock()
+
+    def interrupt_run(coroutine):
+        coroutine.close()
+        raise KeyboardInterrupt()
+
+    event_loop.run_until_complete.side_effect = interrupt_run
+    new_event_loop = MagicMock(return_value=event_loop)
+    set_event_loop = MagicMock()
+    monkeypatch.setattr(asyncio, "new_event_loop", new_event_loop)
+    monkeypatch.setattr(asyncio, "set_event_loop", set_event_loop)
+
+    with pytest.raises(KeyboardInterrupt):
+        client.run()
+
+    set_event_loop.assert_called_once_with(event_loop)
 
 
 # --- _get_base64_message_id tests ---

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
-envlist = py310, py311, py312, flake8
+envlist = py310, py311, py312, py313, py314, flake8
 
 [gh-actions]
 python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 
 [flake8]
 max-line-length = 160
@@ -26,4 +28,3 @@ deps =
 commands =
     pip install -U pip
     pytest --basetemp={envtmpdir}
-

--- a/webex_bot/websockets/webex_websocket_client.py
+++ b/webex_bot/websockets/webex_websocket_client.py
@@ -277,6 +277,12 @@ class WebexWebsocketClient(object):
         asyncio.get_event_loop().create_task(terminate())
 
     def run(self):
+        # Python 3.14 no longer implicitly creates an event loop for
+        # asyncio.get_event_loop(). This client owns its synchronous entry
+        # point, so create and register one explicitly.
+        event_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(event_loop)
+
         if self.device_info is None:
             if self._get_device_info() is None:
                 logger.error('could not get/create device info')
@@ -290,8 +296,7 @@ class WebexWebsocketClient(object):
             logger.debug("WebSocket Received Message(raw): %s\n" % message)
             try:
                 msg = json.loads(message)
-                loop = asyncio.get_event_loop()
-                loop.run_in_executor(None, self._process_incoming_websocket_message, msg)
+                asyncio.get_running_loop().run_in_executor(None, self._process_incoming_websocket_message, msg)
             except Exception as messageProcessingException:
                 logger.warning(
                     f"An exception occurred while processing message. Ignoring. {messageProcessingException}")
@@ -348,7 +353,7 @@ class WebexWebsocketClient(object):
 
         while True:
             try:
-                asyncio.get_event_loop().run_until_complete(_connect_and_listen())
+                event_loop.run_until_complete(_connect_and_listen())
                 # If we get here, the connection was successful, so break out of the loop
                 break
             except InvalidStatus as e:
@@ -369,7 +374,7 @@ class WebexWebsocketClient(object):
 
                     # Add a delay before retrying to avoid hammering the server
                     logger.info(f"Waiting 5 seconds before retry attempt {current_404_retries}...")
-                    asyncio.get_event_loop().run_until_complete(asyncio.sleep(5))
+                    event_loop.run_until_complete(asyncio.sleep(5))
                 else:
                     # For non-404 errors, just raise the exception
                     raise
@@ -386,4 +391,4 @@ class WebexWebsocketClient(object):
 
                 # Wait a bit before reconnecting
                 logger.info("Waiting 5 seconds before attempting to reconnect...")
-                asyncio.get_event_loop().run_until_complete(asyncio.sleep(5))
+                event_loop.run_until_complete(asyncio.sleep(5))


### PR DESCRIPTION
## Summary

- Explicitly create and register the event loop used by WebexWebsocketClient.run().
- Use the running loop when dispatching received messages.
- Add a Python 3.14 regression test and test it in tox and GitHub Actions.

## Validation

- python -m pytest -q on Python 3.14.7: 42 passed, 88.74% coverage.

Python 3.14 no longer creates an event loop implicitly for asyncio.get_event_loop(), which caused WebexBot.run() to fail on startup.